### PR TITLE
[Misc] Add util functions to generate a random seeded real number [0, 1]

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -962,17 +962,27 @@ export default class BattleScene extends SceneBase {
   }
 
   /**
-   * Generates a random number using the current battle's seed
+   * Generates a random integer using the current battle's seed
    *
    * This calls {@linkcode Battle.randSeedInt}(`scene`, {@linkcode range}, {@linkcode min}) in `src/battle.ts`
    * which calls {@linkcode Utils.randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`
    *
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * @param range How large of a range of random integers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
    * @param min The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
-  randBattleSeedInt(range: integer, min: integer = 0): integer {
+  randBattleSeedInt(range: number, min: number = 0): number {
     return this.currentBattle?.randSeedInt(this, range, min);
+  }
+
+  /**
+   * Generates a random number between 0 and 1 using the current battle's seed
+   *
+   * Calls {@linkcode Battle.randSeedFloat} which calls {@linkcode Utils.randSeedFloat}
+   * @returns A random number between 0 and 1
+   */
+  randBattleSeedFloat(): number {
+    return this.currentBattle.randSeedFloat(this);
   }
 
   reset(clearScene: boolean = false, clearData: boolean = false, reloadI18n: boolean = false): void {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -355,8 +355,8 @@ export default class Battle {
   }
 
   /**
-   * Generates a random number using the current battle's seed. Calls {@linkcode Utils.randSeedInt}
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * Generates a random integer using the current battle's seed. Calls {@linkcode Utils.randSeedInt}
+   * @param range How large of a range of random integers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
    * @param min The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
@@ -376,6 +376,27 @@ export default class Battle {
     scene.rngCounter = this.rngCounter++;
     scene.rngSeedOverride = this.battleSeed;
     const ret = Utils.randSeedInt(range, min);
+    this.battleSeedState = Phaser.Math.RND.state();
+    Phaser.Math.RND.state(state);
+    scene.rngCounter = tempRngCounter;
+    scene.rngSeedOverride = tempSeedOverride;
+    return ret;
+  }
+
+  /** Generates a random number between 0 and 1 using the current battle's seed. Calls {@linkcode Utils.randSeedFloat} */
+  randSeedFloat(scene: BattleScene): number {
+    const tempRngCounter = scene.rngCounter;
+    const tempSeedOverride = scene.rngSeedOverride;
+    const state = Phaser.Math.RND.state();
+    if (this.battleSeedState) {
+      Phaser.Math.RND.state(this.battleSeedState);
+    } else {
+      Phaser.Math.RND.sow([ Utils.shiftCharCodes(this.battleSeed, this.turn << 6) ]);
+      console.log("Battle Seed:", this.battleSeed);
+    }
+    scene.rngCounter = this.rngCounter++;
+    scene.rngSeedOverride = this.battleSeed;
+    const ret = Utils.randSeedFloat();
     this.battleSeedState = Phaser.Math.RND.state();
     Phaser.Math.RND.state(state);
     scene.rngCounter = tempRngCounter;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3462,21 +3462,29 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Generates a random number using the current battle's seed, or the global seed if `this.scene.currentBattle` is falsy
+   * Generates a random integer using the current battle's seed, or the global seed if `this.scene.currentBattle` is falsy
    * <!-- @import "../battle".Battle -->
    * This calls either {@linkcode BattleScene.randBattleSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle-scene.ts`
    * which calls {@linkcode Battle.randSeedInt}(`scene`, {@linkcode range}, {@linkcode min}) in `src/battle.ts`
    * which calls {@linkcode Utils.randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`,
    * or it directly calls {@linkcode Utils.randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts` if there is no current battle
    *
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * @param range How large of a range of random integers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
    * @param min The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
-  randSeedInt(range: integer, min: integer = 0): integer {
+  randSeedInt(range: number, min: number = 0): number {
     return this.scene.currentBattle
       ? this.scene.randBattleSeedInt(range, min)
       : Utils.randSeedInt(range, min);
+  }
+
+  /**
+   * Generates a random number between 0 and 1 using the current battle's seed, or the global seed if `this.scene.currentBattle` is falsy
+   * @returns A random number between 0 and 1
+   */
+  randSeedFloat(): number {
+    return this.scene.currentBattle ? this.scene.randBattleSeedFloat() : Utils.randSeedFloat();
   }
 
   /**
@@ -3485,7 +3493,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param max The maximum integer to generate
    * @returns a random integer between {@linkcode min} and {@linkcode max} inclusive
    */
-  randSeedIntRange(min: integer, max: integer): integer {
+  randSeedIntRange(min: number, max: number): number {
     return this.randSeedInt((max - min) + 1, min);
   }
 

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -28,7 +28,7 @@ export class AttemptRunPhase extends PokemonPhase {
 
     applyAbAttrs(RunSuccessAbAttr, playerPokemon, null, false, escapeChance);
 
-    if (playerPokemon.randSeedInt(100) < escapeChance.value) {
+    if (playerPokemon.randSeedFloat() * 100 < escapeChance.value) {
       this.scene.playSound("se/flee");
       this.scene.queueMessage(i18next.t("battle:runAwaySuccess"), null, true, 500);
 
@@ -98,6 +98,6 @@ export class AttemptRunPhase extends PokemonPhase {
     const escapeSlope = (maxChance - minChance) / speedCap;
 
     // This will calculate the escape chance given all of the above and clamp it to the range of [`minChance`, `maxChance`]
-    escapeChance.value = Phaser.Math.Clamp(Math.round((escapeSlope * speedRatio) + minChance + (escapeBonus * this.scene.currentBattle.escapeAttempts++)), minChance, maxChance);
+    escapeChance.value = Phaser.Math.Clamp((escapeSlope * speedRatio) + minChance + (escapeBonus * this.scene.currentBattle.escapeAttempts++), minChance, maxChance);
   }
 }

--- a/src/test/escape-calculations.test.ts
+++ b/src/test/escape-calculations.test.ts
@@ -49,16 +49,16 @@ describe("Escape chance calculations", () => {
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: { pokemonSpeedRatio: number, escapeAttempts: number, expectedEscapeChance: number }[] = [
-      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5 },
-      { pokemonSpeedRatio: 0.1, escapeAttempts: 0, expectedEscapeChance: 7 },
-      { pokemonSpeedRatio: 0.25, escapeAttempts: 0, expectedEscapeChance: 11 },
-      { pokemonSpeedRatio: 0.5, escapeAttempts: 0, expectedEscapeChance: 16 },
+      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5.225 },
+      { pokemonSpeedRatio: 0.1, escapeAttempts: 0, expectedEscapeChance: 7.25 },
+      { pokemonSpeedRatio: 0.25, escapeAttempts: 0, expectedEscapeChance: 10.625 },
+      { pokemonSpeedRatio: 0.5, escapeAttempts: 0, expectedEscapeChance: 16.25 },
       { pokemonSpeedRatio: 0.8, escapeAttempts: 0, expectedEscapeChance: 23 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 28 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 27.5 },
       { pokemonSpeedRatio: 1.2, escapeAttempts: 0, expectedEscapeChance: 32 },
-      { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 39 },
-      { pokemonSpeedRatio: 3, escapeAttempts: 0, expectedEscapeChance: 73 },
-      { pokemonSpeedRatio: 3.8, escapeAttempts: 0, expectedEscapeChance: 91 },
+      { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 38.75 },
+      { pokemonSpeedRatio: 3, escapeAttempts: 0, expectedEscapeChance: 72.5 },
+      { pokemonSpeedRatio: 3.8, escapeAttempts: 0, expectedEscapeChance: 90.5 },
       { pokemonSpeedRatio: 4, escapeAttempts: 0, expectedEscapeChance: 95 },
       { pokemonSpeedRatio: 4.2, escapeAttempts: 0, expectedEscapeChance: 95 },
       { pokemonSpeedRatio: 10, escapeAttempts: 0, expectedEscapeChance: 95 },
@@ -67,10 +67,10 @@ describe("Escape chance calculations", () => {
       { pokemonSpeedRatio: 0.4, escapeAttempts: 1, expectedEscapeChance: 24 },
       { pokemonSpeedRatio: 1.6, escapeAttempts: 2, expectedEscapeChance: 61 },
       { pokemonSpeedRatio: 3.7, escapeAttempts: 5, expectedEscapeChance: 95 },
-      { pokemonSpeedRatio: 0.2, escapeAttempts: 2, expectedEscapeChance: 30 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 3, expectedEscapeChance: 58 },
-      { pokemonSpeedRatio: 2.9, escapeAttempts: 0, expectedEscapeChance: 70 },
-      { pokemonSpeedRatio: 0.01, escapeAttempts: 7, expectedEscapeChance: 75 },
+      { pokemonSpeedRatio: 0.2, escapeAttempts: 2, expectedEscapeChance: 29.5 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 3, expectedEscapeChance: 57.5 },
+      { pokemonSpeedRatio: 2.9, escapeAttempts: 0, expectedEscapeChance: 70.25 },
+      { pokemonSpeedRatio: 0.01, escapeAttempts: 7, expectedEscapeChance: 75.225 },
       { pokemonSpeedRatio: 16.2, escapeAttempts: 4, expectedEscapeChance: 95 },
       { pokemonSpeedRatio: 2, escapeAttempts: 3, expectedEscapeChance: 80 },
     ];
@@ -111,26 +111,26 @@ describe("Escape chance calculations", () => {
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: { pokemonSpeedRatio: number, escapeAttempts: number, expectedEscapeChance: number }[] = [
-      { pokemonSpeedRatio: 0.3, escapeAttempts: 0, expectedEscapeChance: 12 },
-      { pokemonSpeedRatio: 0.7, escapeAttempts: 0, expectedEscapeChance: 21 },
-      { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 39 },
-      { pokemonSpeedRatio: 3, escapeAttempts: 0, expectedEscapeChance: 73 },
+      { pokemonSpeedRatio: 0.3, escapeAttempts: 0, expectedEscapeChance: 11.75 },
+      { pokemonSpeedRatio: 0.7, escapeAttempts: 0, expectedEscapeChance: 20.75 },
+      { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 38.75 },
+      { pokemonSpeedRatio: 3, escapeAttempts: 0, expectedEscapeChance: 72.5 },
       { pokemonSpeedRatio: 9, escapeAttempts: 0, expectedEscapeChance: 95 },
-      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 28 },
+      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5.225 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 27.5 },
       { pokemonSpeedRatio: 4.3, escapeAttempts: 0, expectedEscapeChance: 95 },
-      { pokemonSpeedRatio: 2.7, escapeAttempts: 0, expectedEscapeChance: 66 },
-      { pokemonSpeedRatio: 2.1, escapeAttempts: 0, expectedEscapeChance: 52 },
-      { pokemonSpeedRatio: 1.8, escapeAttempts: 0, expectedEscapeChance: 46 },
+      { pokemonSpeedRatio: 2.7, escapeAttempts: 0, expectedEscapeChance: 65.75 },
+      { pokemonSpeedRatio: 2.1, escapeAttempts: 0, expectedEscapeChance: 52.25 },
+      { pokemonSpeedRatio: 1.8, escapeAttempts: 0, expectedEscapeChance: 45.5 },
       { pokemonSpeedRatio: 6, escapeAttempts: 0, expectedEscapeChance: 95 },
 
       // retries section
-      { pokemonSpeedRatio: 0.9, escapeAttempts: 1, expectedEscapeChance: 35 },
+      { pokemonSpeedRatio: 0.9, escapeAttempts: 1, expectedEscapeChance: 35.25 },
       { pokemonSpeedRatio: 3.6, escapeAttempts: 2, expectedEscapeChance: 95 },
-      { pokemonSpeedRatio: 0.03, escapeAttempts: 7, expectedEscapeChance: 76 },
-      { pokemonSpeedRatio: 0.02, escapeAttempts: 7, expectedEscapeChance: 75 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 5, expectedEscapeChance: 78 },
-      { pokemonSpeedRatio: 0.7, escapeAttempts: 3, expectedEscapeChance: 51 },
+      { pokemonSpeedRatio: 0.03, escapeAttempts: 7, expectedEscapeChance: 75.675 },
+      { pokemonSpeedRatio: 0.02, escapeAttempts: 7, expectedEscapeChance: 75.45 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 5, expectedEscapeChance: 77.5 },
+      { pokemonSpeedRatio: 0.7, escapeAttempts: 3, expectedEscapeChance: 50.75 },
       { pokemonSpeedRatio: 2.4, escapeAttempts: 9, expectedEscapeChance: 95 },
       { pokemonSpeedRatio: 1.8, escapeAttempts: 7, expectedEscapeChance: 95 },
       { pokemonSpeedRatio: 2, escapeAttempts: 10, expectedEscapeChance: 95 },
@@ -171,35 +171,35 @@ describe("Escape chance calculations", () => {
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: { pokemonSpeedRatio: number, escapeAttempts: number, expectedEscapeChance: number }[] = [
-      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5 },
-      { pokemonSpeedRatio: 0.1, escapeAttempts: 0, expectedEscapeChance: 5 },
-      { pokemonSpeedRatio: 0.25, escapeAttempts: 0, expectedEscapeChance: 6 },
-      { pokemonSpeedRatio: 0.5, escapeAttempts: 0, expectedEscapeChance: 7 },
-      { pokemonSpeedRatio: 0.8, escapeAttempts: 0, expectedEscapeChance: 8 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 8 },
+      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5.033 },
+      { pokemonSpeedRatio: 0.1, escapeAttempts: 0, expectedEscapeChance: 5.333 },
+      { pokemonSpeedRatio: 0.25, escapeAttempts: 0, expectedEscapeChance: 5.833 },
+      { pokemonSpeedRatio: 0.5, escapeAttempts: 0, expectedEscapeChance: 6.666 },
+      { pokemonSpeedRatio: 0.8, escapeAttempts: 0, expectedEscapeChance: 7.666 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 8.333 },
       { pokemonSpeedRatio: 1.2, escapeAttempts: 0, expectedEscapeChance: 9 },
       { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 10 },
       { pokemonSpeedRatio: 3, escapeAttempts: 0, expectedEscapeChance: 15 },
-      { pokemonSpeedRatio: 3.8, escapeAttempts: 0, expectedEscapeChance: 18 },
-      { pokemonSpeedRatio: 4, escapeAttempts: 0, expectedEscapeChance: 18 },
+      { pokemonSpeedRatio: 3.8, escapeAttempts: 0, expectedEscapeChance: 17.666 },
+      { pokemonSpeedRatio: 4, escapeAttempts: 0, expectedEscapeChance: 18.333 },
       { pokemonSpeedRatio: 4.2, escapeAttempts: 0, expectedEscapeChance: 19 },
-      { pokemonSpeedRatio: 4.7, escapeAttempts: 0, expectedEscapeChance: 21 },
-      { pokemonSpeedRatio: 5, escapeAttempts: 0, expectedEscapeChance: 22 },
-      { pokemonSpeedRatio: 5.9, escapeAttempts: 0, expectedEscapeChance: 25 },
+      { pokemonSpeedRatio: 4.7, escapeAttempts: 0, expectedEscapeChance: 20.666 },
+      { pokemonSpeedRatio: 5, escapeAttempts: 0, expectedEscapeChance: 21.666 },
+      { pokemonSpeedRatio: 5.9, escapeAttempts: 0, expectedEscapeChance: 24.666 },
       { pokemonSpeedRatio: 6, escapeAttempts: 0, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 6.7, escapeAttempts: 0, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 10, escapeAttempts: 0, expectedEscapeChance: 25 },
 
       // retries section
-      { pokemonSpeedRatio: 0.4, escapeAttempts: 1, expectedEscapeChance: 8 },
-      { pokemonSpeedRatio: 1.6, escapeAttempts: 2, expectedEscapeChance: 14 },
+      { pokemonSpeedRatio: 0.4, escapeAttempts: 1, expectedEscapeChance: 8.333 },
+      { pokemonSpeedRatio: 1.6, escapeAttempts: 2, expectedEscapeChance: 14.333 },
       { pokemonSpeedRatio: 3.7, escapeAttempts: 5, expectedEscapeChance: 25 },
-      { pokemonSpeedRatio: 0.2, escapeAttempts: 2, expectedEscapeChance: 10 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 3, expectedEscapeChance: 14 },
-      { pokemonSpeedRatio: 2.9, escapeAttempts: 0, expectedEscapeChance: 15 },
-      { pokemonSpeedRatio: 0.01, escapeAttempts: 7, expectedEscapeChance: 19 },
+      { pokemonSpeedRatio: 0.2, escapeAttempts: 2, expectedEscapeChance: 9.666 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 3, expectedEscapeChance: 14.333 },
+      { pokemonSpeedRatio: 2.9, escapeAttempts: 0, expectedEscapeChance: 14.666 },
+      { pokemonSpeedRatio: 0.01, escapeAttempts: 7, expectedEscapeChance: 19.033 },
       { pokemonSpeedRatio: 16.2, escapeAttempts: 4, expectedEscapeChance: 25 },
-      { pokemonSpeedRatio: 2, escapeAttempts: 3, expectedEscapeChance: 18 },
+      { pokemonSpeedRatio: 2, escapeAttempts: 3, expectedEscapeChance: 17.666 },
       { pokemonSpeedRatio: 4.5, escapeAttempts: 1, expectedEscapeChance: 22 },
       { pokemonSpeedRatio: 6.8, escapeAttempts: 6, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 5.2, escapeAttempts: 8, expectedEscapeChance: 25 },
@@ -217,7 +217,7 @@ describe("Escape chance calculations", () => {
       // set playerPokemon's speed to a multiple of the enemySpeed
       vi.spyOn(playerPokemon[0], "stats", "get").mockReturnValue([20, 20, 20, 20, 20, escapeChances[i].pokemonSpeedRatio * enemySpeed]);
       phase.attemptRunAway(playerPokemon, enemyField, escapePercentage);
-      expect(escapePercentage.value).toBe(escapeChances[i].expectedEscapeChance);
+      expect(escapePercentage.value).toBeCloseTo(escapeChances[i].expectedEscapeChance);
     }
   }, 20000);
 
@@ -249,20 +249,20 @@ describe("Escape chance calculations", () => {
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: { pokemonSpeedRatio: number, escapeAttempts: number, expectedEscapeChance: number }[] = [
       { pokemonSpeedRatio: 0.3, escapeAttempts: 0, expectedEscapeChance: 6 },
-      { pokemonSpeedRatio: 0.7, escapeAttempts: 0, expectedEscapeChance: 7 },
+      { pokemonSpeedRatio: 0.7, escapeAttempts: 0, expectedEscapeChance: 7.333 },
       { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 10 },
       { pokemonSpeedRatio: 3, escapeAttempts: 0, expectedEscapeChance: 15 },
       { pokemonSpeedRatio: 9, escapeAttempts: 0, expectedEscapeChance: 25 },
-      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 8 },
-      { pokemonSpeedRatio: 4.3, escapeAttempts: 0, expectedEscapeChance: 19 },
+      { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5.033 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 0, expectedEscapeChance: 8.333 },
+      { pokemonSpeedRatio: 4.3, escapeAttempts: 0, expectedEscapeChance: 19.333 },
       { pokemonSpeedRatio: 2.7, escapeAttempts: 0, expectedEscapeChance: 14 },
       { pokemonSpeedRatio: 2.1, escapeAttempts: 0, expectedEscapeChance: 12 },
       { pokemonSpeedRatio: 1.8, escapeAttempts: 0, expectedEscapeChance: 11 },
       { pokemonSpeedRatio: 6, escapeAttempts: 0, expectedEscapeChance: 25 },
-      { pokemonSpeedRatio: 4, escapeAttempts: 0, expectedEscapeChance: 18 },
+      { pokemonSpeedRatio: 4, escapeAttempts: 0, expectedEscapeChance: 18.333 },
       { pokemonSpeedRatio: 5.7, escapeAttempts: 0, expectedEscapeChance: 24 },
-      { pokemonSpeedRatio: 5, escapeAttempts: 0, expectedEscapeChance: 22 },
+      { pokemonSpeedRatio: 5, escapeAttempts: 0, expectedEscapeChance: 21.666 },
       { pokemonSpeedRatio: 6.1, escapeAttempts: 0, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 6.8, escapeAttempts: 0, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 10, escapeAttempts: 0, expectedEscapeChance: 25 },
@@ -270,16 +270,16 @@ describe("Escape chance calculations", () => {
       // retries section
       { pokemonSpeedRatio: 0.9, escapeAttempts: 1, expectedEscapeChance: 10 },
       { pokemonSpeedRatio: 3.6, escapeAttempts: 2, expectedEscapeChance: 21 },
-      { pokemonSpeedRatio: 0.03, escapeAttempts: 7, expectedEscapeChance: 19 },
-      { pokemonSpeedRatio: 0.02, escapeAttempts: 7, expectedEscapeChance: 19 },
-      { pokemonSpeedRatio: 1, escapeAttempts: 5, expectedEscapeChance: 18 },
-      { pokemonSpeedRatio: 0.7, escapeAttempts: 3, expectedEscapeChance: 13 },
+      { pokemonSpeedRatio: 0.03, escapeAttempts: 7, expectedEscapeChance: 19.1 },
+      { pokemonSpeedRatio: 0.02, escapeAttempts: 7, expectedEscapeChance: 19.066 },
+      { pokemonSpeedRatio: 1, escapeAttempts: 5, expectedEscapeChance: 18.333 },
+      { pokemonSpeedRatio: 0.7, escapeAttempts: 3, expectedEscapeChance: 13.333 },
       { pokemonSpeedRatio: 2.4, escapeAttempts: 9, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 1.8, escapeAttempts: 7, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 2, escapeAttempts: 10, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 3, escapeAttempts: 1, expectedEscapeChance: 17 },
       { pokemonSpeedRatio: 4.5, escapeAttempts: 3, expectedEscapeChance: 25 },
-      { pokemonSpeedRatio: 3.7, escapeAttempts: 1, expectedEscapeChance: 19 },
+      { pokemonSpeedRatio: 3.7, escapeAttempts: 1, expectedEscapeChance: 19.333 },
       { pokemonSpeedRatio: 6.5, escapeAttempts: 1, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 12, escapeAttempts: 4, expectedEscapeChance: 25 },
       { pokemonSpeedRatio: 5.2, escapeAttempts: 2, expectedEscapeChance: 25 },
@@ -295,7 +295,7 @@ describe("Escape chance calculations", () => {
       vi.spyOn(playerPokemon[1], "stats", "get").mockReturnValue([20, 20, 20, 20, 20, escapeChances[i].pokemonSpeedRatio * totalEnemySpeed - playerPokemon[0].stats[5]]);
       phase.attemptRunAway(playerPokemon, enemyField, escapePercentage);
       // checks to make sure the escape values are the same
-      expect(escapePercentage.value).toBe(escapeChances[i].expectedEscapeChance);
+      expect(escapePercentage.value).toBeCloseTo(escapeChances[i].expectedEscapeChance);
       // checks to make sure the sum of the player's speed for all pokemon is equal to the appropriate ratio of the total enemy speed
       expect(playerPokemon[0].stats[5] + playerPokemon[1].stats[5]).toBe(escapeChances[i].pokemonSpeedRatio * totalEnemySpeed);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,11 +71,11 @@ export function padInt(value: integer, length: integer, padWith?: string): strin
 }
 
 /**
-* Returns a random integer between min and min + range
+* Returns a random integer between min and min + range using {@linkcode Math.random}
 * @param range The amount of possible numbers
-* @param min The starting number
+* @param min The starting integer
 */
-export function randInt(range: integer, min: integer = 0): integer {
+export function randInt(range: number, min: number = 0): number {
   if (range === 1) {
     return min;
   }
@@ -83,12 +83,12 @@ export function randInt(range: integer, min: integer = 0): integer {
 }
 
 /**
- * Generates a random number using the global seed, or the current battle's seed if called via `Battle.randSeedInt`
- * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+ * Generates a random integer using the global seed, or the current battle's seed if called via `Battle.randSeedInt`
+ * @param range How large of a range of random integers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
  * @param min The minimum integer to pick, default `0`
  * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
  */
-export function randSeedInt(range: integer, min: integer = 0): integer {
+export function randSeedInt(range: number, min: number = 0): number {
   if (range <= 1) {
     return min;
   }
@@ -96,11 +96,18 @@ export function randSeedInt(range: integer, min: integer = 0): integer {
 }
 
 /**
+ * Generates a random number between 0 and 1 using the global seed, or the current battle's seed if called via `Battle.randSeedFloat`
+ */
+export function randSeedFloat(): number {
+  return Phaser.Math.RND.frac();
+}
+
+/**
 * Returns a random integer between min and max (non-inclusive)
-* @param min The lowest number
-* @param max The highest number
+* @param min The lowest integer
+* @param max The highest integer
 */
-export function randIntRange(min: integer, max: integer): integer {
+export function randIntRange(min: number, max: number): number {
   return randInt(max - min, min);
 }
 


### PR DESCRIPTION
Just leaving this here for now.

## What are the changes the user will see?
Realistically, none.

## Why am I making these changes?
Submitted on behalf of discord user `@mistaah.` 🤷 

## What are the changes from a developer perspective?
Mostly this just adds a new set of utility functions that mirrors `randSeedInt()` et al, except it generates a random seeded real number between 0 and 1 by replacing `Phaser.Math.RND.integerInRange` with `Phaser.Math.RND.frac`.
As a demonstration of the functionality, the escape chance calculation is updated to use the new method, thus increasing its precision by a tiny amount.

## How to test the changes?
`npm run test escape-calculations`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
