### PR TITLE
[Hotfix] Enable save importing on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.5.2",
+			"version": "1.5.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -247,17 +247,15 @@ export default class MenuUiHandler extends MessageUiHandler {
       },
       keepOpen: true
     });
-    if (Utils.isLocal || Utils.isBeta) {
-      manageDataOptions.push({
-        label: i18next.t("menuUiHandler:importData"),
-        handler: () => {
-          ui.revertMode();
-          globalScene.gameData.importData(GameDataType.SYSTEM);
-          return true;
-        },
-        keepOpen: true
-      });
-    }
+    manageDataOptions.push({
+      label: i18next.t("menuUiHandler:importData"),
+      handler: () => {
+        ui.revertMode();
+        globalScene.gameData.importData(GameDataType.SYSTEM);
+        return true;
+      },
+      keepOpen: true
+    });
     manageDataOptions.push({
       label: i18next.t("menuUiHandler:exportData"),
       handler: () => {


### PR DESCRIPTION
-- making this to save pr description text for later use --

## What are the changes the user will see?
Players will now be able to import account save data on main.

## Why am I making these changes?
Save corruption issues due to server instability means trying to prevent "cheating" is no longer worth it.

## What are the changes from a developer perspective?
An `if` statement checking that the current server is running locally or as beta is removed from the "import data" option.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?